### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,8 @@ jobs:
   security:
     name: Security & Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/lukaszzychal/moviemind-api-public/security/code-scanning/4](https://github.com/lukaszzychal/moviemind-api-public/security/code-scanning/4)

To fix the issue, add an explicit `permissions` block to the `security` job in `.github/workflows/ci.yml`. This block should specify the minimum set of permissions required, which for this job is almost certainly just `contents: read`, since it only checks out code and runs local commands without needing to push code or interact with other GitHub resources. Insert the block directly after `runs-on: ubuntu-latest` (line 83), using the YAML syntax. No imports or other code changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Declare explicit `permissions: contents: read` for the `security` job in `.github/workflows/ci.yml`.
> 
> - **CI Workflow (`.github/workflows/ci.yml`)**:
>   - **Security job**: Add explicit `permissions` block with `contents: read`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68e883c47a19fe0b4737d307b3de69f8d17f6b11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->