### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ on:
 jobs:
   test:
     name: Test PHP ${{ matrix.php-versions }}
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
Potential fix for [https://github.com/lukaszzychal/moviemind-api-public/security/code-scanning/1](https://github.com/lukaszzychal/moviemind-api-public/security/code-scanning/1)

To fix this issue, add an explicit `permissions` block to the `test` job in `.github/workflows/ci.yml` (line 25) to restrict the GitHub token to the minimum access required. Since the job performs only code checkout, dependency installation, and test running with no steps that require write access, the minimal required permission is likely `contents: read`. The change consists of inserting a `permissions:` key with `contents: read` immediately after the `name:` key (and before `runs-on:`) for the `test` job (lines 25-26).

No changes to imports, method definitions, or additional dependencies are required, as this is a YAML change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `permissions: contents: read` to the `test` job in `.github/workflows/ci.yml` to restrict GITHUB_TOKEN scope.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f42fc5b7c50904ad9007dace6b9cf8c0327e0fb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->