### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-security-scan.yml
+++ b/.github/workflows/code-security-scan.yml
@@ -1,4 +1,6 @@
 name: GitLeaks Security Scan
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/lukaszzychal/moviemind-api-public/security/code-scanning/2](https://github.com/lukaszzychal/moviemind-api-public/security/code-scanning/2)

The best way to fix the problem is to add an explicit `permissions:` block to the root of the workflow YAML file, following GitHub's recommended least privilege policy. The minimal required permission for these jobs is typically `contents: read`, which allows the jobs to read the repository contents during actions like `checkout` and running scans, but restricts write access to repository data. No functionality will be lost since none of the jobs require write access to repository contents or other resources. The `permissions:` block should be inserted directly after the workflow `name:` declaration and before the `on:` block so that it applies to all jobs in the workflow (unless a job overrides it with its own `permissions:` block). No external dependencies or new imports are required to implement this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
