### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-security-scan.yml
+++ b/.github/workflows/code-security-scan.yml
@@ -1,4 +1,6 @@
 name: GitLeaks Security Scan
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/lukaszzychal/moviemind-api-public/security/code-scanning/3](https://github.com/lukaszzychal/moviemind-api-public/security/code-scanning/3)

The best way to fix this problem is to add a `permissions` block to the workflow, restricting the GITHUB_TOKEN permissions to the minimal set required by the jobs. Since both jobs in the workflow (`gitleaks` and `security-audit`) only read repository contents and upload artifacts (which uses the GITHUB_TOKEN for authentication, but does not require write access to repo contents), `contents: read` is sufficient and recommended. The `permissions` block can be set either at the root of the workflow, applying to all jobs unless overridden, or individually in each job. For maintainability and least privilege, adding a root-level block is appropriate for this workflow. This change should be inserted after the `name` and before the `on` block, as per GitHub workflow syntax.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
