### PR TITLE
feat: add tasks for series/TV shows (DDD) and breaking change detection rule

### DIFF
--- a/.cursor/rules/breaking-change-detection.mdc
+++ b/.cursor/rules/breaking-change-detection.mdc
@@ -1,0 +1,99 @@
+---
+alwaysApply: true
+---
+
+# Breaking Change Detection and Impact Analysis
+
+## Principle
+
+**Treat all changes as if they were being deployed to production with full data.**
+
+Before making any change that could potentially:
+- Damage existing data in the database
+- Break existing functionality
+- Change API contracts
+- Modify database schema in incompatible ways
+- Remove or rename fields/columns
+- Change behavior of existing methods
+
+**STOP and perform impact analysis.**
+
+## Required Analysis
+
+### 1. Identify Breaking Changes
+
+Check if the change:
+- Modifies database schema (migrations, columns, constraints)
+- Changes model relationships or methods
+- Alters API request/response formats
+- Removes or renames fields/columns
+- Changes behavior of existing methods
+- Modifies validation rules
+- Changes slug generation/parsing logic
+- Alters job processing logic
+
+### 2. Impact Assessment
+
+For each identified breaking change:
+- **Data Impact:** Will existing data be affected? How?
+- **API Impact:** Will API consumers be affected? Which endpoints?
+- **Functionality Impact:** Will existing features break? Which ones?
+- **Migration Impact:** Can data be migrated safely? How?
+
+### 3. Alternatives Analysis
+
+Document:
+- Alternative approaches that avoid breaking changes
+- Backward compatibility solutions
+- Gradual migration strategies
+- Feature flags for safe rollout
+
+### 4. Safe Change Process
+
+If breaking change is necessary, provide:
+- Database migration strategy (nullable columns, default values, data migration)
+- Backward compatibility layer (if possible)
+- API versioning strategy (if needed)
+- Rollback plan
+- Testing strategy (existing data, edge cases)
+
+## Workflow
+
+1. **Before making changes:**
+   - Analyze if change is breaking
+   - If breaking → STOP
+   - Document impact analysis
+   - Propose alternatives
+   - Get approval or confirmation
+
+2. **If breaking change is approved:**
+   - Create migration plan
+   - Implement backward compatibility (if possible)
+   - Add comprehensive tests
+   - Update documentation
+   - Create rollback strategy
+
+3. **Examples of breaking changes:**
+   - Adding NOT NULL constraint to existing column
+   - Removing column from table
+   - Changing column type without migration
+   - Removing or renaming model method
+   - Changing API response format
+   - Modifying slug generation logic (affects existing slugs)
+   - Changing validation rules (may reject existing data)
+
+## Exceptions
+
+Changes that are NOT breaking:
+- Adding new nullable columns
+- Adding new optional API fields
+- Adding new methods (without removing old ones)
+- Adding new features (without modifying existing)
+- Bug fixes that restore intended behavior
+
+## Enforcement
+
+- AI Agent MUST analyze changes before implementation
+- AI Agent MUST stop and inform user if breaking change detected
+- AI Agent MUST provide impact analysis and alternatives
+- AI Agent MUST propose safe change process before proceeding

--- a/docs/issue/en/TASKS.md
+++ b/docs/issue/en/TASKS.md
@@ -526,6 +526,79 @@ Every entry follows this structure:
 
 ---
 
+#### `TASK-041` – Add TV series and programs (DDD approach)
+- **Status:** ⏳ PENDING
+- **Priority:** 🟡 Medium
+- **Estimated time:** 30-40 hours
+- **Start time:** --
+- **End time:** --
+- **Duration:** --
+- **Execution:** TBD
+- **Description:** Implementation of separate domain entities Series and TVShow according to Domain-Driven Design. Movie and Series/TV Show are different domain concepts - Movie has no episodes, Series has.
+- **Details:**
+  - Create `Series` model with `series` table:
+    - Fields: `title`, `slug`, `start_year`, `end_year`, `network`, `seasons`, `episodes`, `director`, `genres`, `default_description_id`
+    - Relations: `descriptions()`, `people()` (series_person), `genres()`
+  - Create `TVShow` model with `tv_shows` table:
+    - Fields: `title`, `slug`, `start_year`, `end_year`, `network`, `format`, `episodes`, `runtime_per_episode`, `genres`, `default_description_id`
+    - Relations: `descriptions()`, `people()` (tv_show_person), `genres()`
+  - Create common interfaces/trait:
+    - `DescribableContent` interface (for descriptions)
+    - `Sluggable` trait (for slug generation/parsing)
+    - `HasPeople` interface (for relations with Person)
+  - Create `SeriesDescription` and `TVShowDescription` models (or polymorphic `ContentDescription`)
+  - Create `SeriesRepository` and `TVShowRepository` (shared logic through interfaces)
+  - Create `SeriesController` and `TVShowController` (shared logic through interfaces)
+  - Create jobs: `RealGenerateSeriesJob`, `MockGenerateSeriesJob`, `RealGenerateTVShowJob`, `MockGenerateTVShowJob`
+  - Update `GenerateController` (handle SERIES, TV_SHOW)
+  - Create enum `EntityType` (MOVIE, SERIES, TV_SHOW, PERSON)
+  - Update OpenAPI schema
+  - Migrations for tables `series`, `tv_shows`, `series_person`, `tv_show_person`, `series_descriptions`, `tv_show_descriptions`
+  - Tests (automated and manual)
+  - Documentation
+- **Dependencies:** none
+- **Created:** 2025-01-09
+---
+
+#### `TASK-042` – Analysis of possible extensions (types and kinds)
+- **Status:** ⏳ PENDING
+- **Priority:** 🟢 Low
+- **Estimated time:** 4-6 hours
+- **Start time:** --
+- **End time:** --
+- **Duration:** --
+- **Execution:** TBD
+- **Description:** Analysis and documentation of possible system extensions with new content types and kinds.
+- **Details:**
+  - Analyze current structure (Movie, Person, Series, TVShow)
+  - Identify potential extensions (e.g., Documentaries, Short Films, Web Series, Podcasts, Books, Music Albums)
+  - Analyze impact on API, database, jobs
+  - Analyze common interfaces and refactoring possibilities
+  - Document recommendations and alternatives
+  - Create document in `docs/knowledge/technical/`
+- **Dependencies:** none
+- **Created:** 2025-01-09
+---
+
+#### `TASK-043` – Implement BREAKING CHANGE detection rule
+- **Status:** ⏳ PENDING
+- **Priority:** 🔴 High
+- **Estimated time:** 2-3 hours
+- **Start time:** --
+- **End time:** --
+- **Duration:** --
+- **Execution:** TBD
+- **Description:** Add rule to cursor/rules requiring BREAKING CHANGE analysis before making changes. Rule requires treating changes as if they were in production with full data.
+- **Details:**
+  - Create `.cursor/rules/breaking-change-detection.mdc`
+  - Rule: treat changes as if they were in production with full data
+  - Require impact analysis before implementation (data impact, API impact, functionality impact)
+  - Analyze alternatives and safe change process (migrations, backward compatibility, etc.)
+  - Process: STOP → analysis → documentation → alternatives → safe process → approval
+- **Dependencies:** none
+- **Created:** 2025-01-09
+---
+
 #### `TASK-028` – Verify priority label sync from TASKS to Issues
 - **Status:** ⏳ PENDING
 - **Priority:** 🟡 Medium

--- a/docs/issue/pl/TASKS.md
+++ b/docs/issue/pl/TASKS.md
@@ -505,6 +505,79 @@ Każde zadanie ma następującą strukturę:
 
 ---
 
+#### `TASK-041` - Dodanie seriali i programów telewizyjnych (DDD approach)
+- **Status:** ⏳ PENDING
+- **Priorytet:** 🟡 Średni
+- **Szacowany czas:** 30-40 godzin
+- **Czas rozpoczęcia:** --
+- **Czas zakończenia:** --
+- **Czas realizacji:** -- (Agent AI obliczy automatycznie przy trybie 🤖)
+- **Realizacja:** Do ustalenia
+- **Opis:** Implementacja osobnych encji domenowych Series i TVShow zgodnie z Domain-Driven Design. Movie i Series/TV Show to różne koncepty domenowe - Movie nie ma odcinków, Series ma.
+- **Szczegóły:**
+  - Utworzenie modelu `Series` z tabelą `series`:
+    - Pola: `title`, `slug`, `start_year`, `end_year`, `network`, `seasons`, `episodes`, `director`, `genres`, `default_description_id`
+    - Relacje: `descriptions()`, `people()` (series_person), `genres()`
+  - Utworzenie modelu `TVShow` z tabelą `tv_shows`:
+    - Pola: `title`, `slug`, `start_year`, `end_year`, `network`, `format`, `episodes`, `runtime_per_episode`, `genres`, `default_description_id`
+    - Relacje: `descriptions()`, `people()` (tv_show_person), `genres()`
+  - Utworzenie wspólnych interfejsów/trait:
+    - `DescribableContent` interface (dla descriptions)
+    - `Sluggable` trait (dla slug generation/parsing)
+    - `HasPeople` interface (dla relacji z Person)
+  - Utworzenie `SeriesDescription` i `TVShowDescription` modeli (lub polimorficzna `ContentDescription`)
+  - Utworzenie `SeriesRepository` i `TVShowRepository` (wspólna logika przez interfejsy)
+  - Utworzenie `SeriesController` i `TVShowController` (wspólna logika przez interfejsy)
+  - Utworzenie jobów: `RealGenerateSeriesJob`, `MockGenerateSeriesJob`, `RealGenerateTVShowJob`, `MockGenerateTVShowJob`
+  - Aktualizacja `GenerateController` (obsługa SERIES, TV_SHOW)
+  - Utworzenie enum `EntityType` (MOVIE, SERIES, TV_SHOW, PERSON)
+  - Aktualizacja OpenAPI schema
+  - Migracje dla tabel `series`, `tv_shows`, `series_person`, `tv_show_person`, `series_descriptions`, `tv_show_descriptions`
+  - Testy (automatyczne i manualne)
+  - Dokumentacja
+- **Zależności:** Brak
+- **Utworzone:** 2025-01-09
+---
+
+#### `TASK-042` - Analiza możliwych rozszerzeń typów i rodzajów
+- **Status:** ⏳ PENDING
+- **Priorytet:** 🟢 Niski
+- **Szacowany czas:** 4-6 godzin
+- **Czas rozpoczęcia:** --
+- **Czas zakończenia:** --
+- **Czas realizacji:** -- (Agent AI obliczy automatycznie przy trybie 🤖)
+- **Realizacja:** Do ustalenia
+- **Opis:** Analiza i dokumentacja możliwych rozszerzeń systemu o nowe typy treści i rodzaje.
+- **Szczegóły:**
+  - Analiza obecnej struktury (Movie, Person, Series, TVShow)
+  - Identyfikacja potencjalnych rozszerzeń (np. Documentaries, Short Films, Web Series, Podcasts, Books, Music Albums)
+  - Analiza wpływu na API, bazę danych, joby
+  - Analiza wspólnych interfejsów i możliwości refaktoryzacji
+  - Dokumentacja rekomendacji i alternatyw
+  - Utworzenie dokumentu w `docs/knowledge/technical/`
+- **Zależności:** Brak
+- **Utworzone:** 2025-01-09
+---
+
+#### `TASK-043` - Implementacja zasady wykrywania BREAKING CHANGE
+- **Status:** ⏳ PENDING
+- **Priorytet:** 🔴 Wysoki
+- **Szacowany czas:** 2-3 godziny
+- **Czas rozpoczęcia:** --
+- **Czas zakończenia:** --
+- **Czas realizacji:** -- (Agent AI obliczy automatycznie przy trybie 🤖)
+- **Realizacja:** Do ustalenia
+- **Opis:** Dodanie zasady do cursor/rules wymagającej analizy BREAKING CHANGE przed wprowadzeniem zmian. Zasada wymaga traktowania zmian jakby były na produkcji z pełnymi danymi.
+- **Szczegóły:**
+  - Utworzenie `.cursor/rules/breaking-change-detection.mdc`
+  - Zasada: traktować zmiany jakby były na produkcji z pełnymi danymi
+  - Wymaganie analizy skutków zmian przed wprowadzeniem (data impact, API impact, functionality impact)
+  - Analiza alternatyw i bezpiecznego procesu zmiany (migracje, backward compatibility, etc.)
+  - Proces: STOP → analiza → dokumentacja → alternatywy → bezpieczny proces → approval
+- **Zależności:** Brak
+- **Utworzone:** 2025-01-09
+---
+
 #### `TASK-028` - Weryfikacja tagów priorytetu w synchronizacji TASKS -> Issues
 - **Status:** ⏳ PENDING
 - **Priorytet:** 🟡 Średni


### PR DESCRIPTION
## Changes

- Added 3 new tasks to TASKS.md (PL and EN):
  - TASK-041: Add TV series and programs (DDD approach) - separate domain entities for Series and TVShow
  - TASK-042: Analysis of possible extensions (types and kinds)
  - TASK-043: Implement BREAKING CHANGE detection rule

- Created new rule file: `.cursor/rules/breaking-change-detection.mdc`
  - Rule requires treating all changes as if they were in production with full data
  - Requires impact analysis before making breaking changes
  - Provides workflow for safe change process

## Approach

Following Domain-Driven Design principles:
- Movie and Series/TV Show are different domain concepts
- Movie has no episodes, Series has
- Separate entities with common interfaces/traits for shared behavior

## Related

- Addresses user request for adding TV series and programs
- Addresses user request for breaking change detection rule