### PR TITLE
feat: add AI service and active feature flags to root endpoint

### DIFF
--- a/api/tests/Feature/ExampleTest.php
+++ b/api/tests/Feature/ExampleTest.php
@@ -2,11 +2,20 @@
 
 namespace Tests\Feature;
 
-// use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class ExampleTest extends TestCase
 {
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->artisan('migrate');
+        $this->artisan('db:seed');
+    }
+
     /**
      * A basic test example.
      */
@@ -14,6 +23,47 @@ class ExampleTest extends TestCase
     {
         $response = $this->get('/');
 
-        $response->assertStatus(200);
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'name',
+                'version',
+                'status',
+                'environment',
+                'ai_service',
+                'feature_flags' => [
+                    'active',
+                ],
+                'endpoints',
+                'documentation',
+            ]);
+    }
+
+    public function test_root_endpoint_includes_ai_service(): void
+    {
+        $response = $this->getJson('/');
+
+        $response->assertOk();
+        $data = $response->json();
+
+        $this->assertArrayHasKey('ai_service', $data);
+        $this->assertContains($data['ai_service'], ['mock', 'real']);
+    }
+
+    public function test_root_endpoint_includes_active_feature_flags(): void
+    {
+        $response = $this->getJson('/');
+
+        $response->assertOk();
+        $data = $response->json();
+
+        $this->assertArrayHasKey('feature_flags', $data);
+        $this->assertArrayHasKey('active', $data['feature_flags']);
+        $this->assertIsArray($data['feature_flags']['active']);
+
+        // Check structure of active flags
+        if (! empty($data['feature_flags']['active'])) {
+            $firstFlag = $data['feature_flags']['active'][0];
+            $this->assertArrayHasKey('name', $firstFlag);
+        }
     }
 }


### PR DESCRIPTION
## Changes

- Add `ai_service` field to root endpoint showing current AI service (mock/real)
- Add `feature_flags.active` array with active flags information (name, description, category)
- Update `ExampleTest` to verify new fields structure
- Root endpoint now provides complete service configuration info

## Example Response

```json
{
  "name": "MovieMind API",
  "version": "1.0.0",
  "status": "ok",
  "environment": "staging",
  "ai_service": "real",
  "feature_flags": {
    "active": [
      {
        "name": "ai_description_generation",
        "description": "Enables AI-generated movie/series descriptions.",
        "category": "core_ai"
      }
    ]
  },
  "endpoints": { ... },
  "documentation": { ... }
}
```

## Testing

- ✅ All tests pass (4 passed, 18 assertions)
- ✅ Laravel Pint formatting OK
- ✅ PHPStan no errors
- ✅ GitLeaks no secrets

## Related

- Addresses user request to add AI service and active flags info to root endpoint
- Improves API discoverability and configuration visibility