### PR TITLE
refactor: move root endpoint to /debug and add welcome JSON endpoint

### DIFF
--- a/api/routes/web.php
+++ b/api/routes/web.php
@@ -5,7 +5,14 @@ use Illuminate\Support\Facades\Route;
 
 // Welcome endpoint
 Route::get('/', function () {
-    return view('welcome');
+    return response()->json([
+        'message' => 'Welcome to MovieMind API',
+        'status' => 'ok',
+        'version' => '1.0.0',
+        'api' => '/api/v1',
+    ], 200, [
+        'Content-Type' => 'application/json',
+    ]);
 });
 
 // Debug endpoint (moved from root)

--- a/api/tests/Feature/ExampleTest.php
+++ b/api/tests/Feature/ExampleTest.php
@@ -38,12 +38,23 @@ class ExampleTest extends TestCase
             ]);
     }
 
-    public function test_root_endpoint_returns_welcome_view(): void
+    public function test_root_endpoint_returns_welcome_json(): void
     {
-        $response = $this->get('/');
+        $response = $this->getJson('/');
 
         $response->assertOk()
-            ->assertViewIs('welcome');
+            ->assertJsonStructure([
+                'message',
+                'status',
+                'version',
+                'api',
+            ]);
+
+        $data = $response->json();
+        $this->assertSame('Welcome to MovieMind API', $data['message']);
+        $this->assertSame('ok', $data['status']);
+        $this->assertSame('1.0.0', $data['version']);
+        $this->assertSame('/api/v1', $data['api']);
     }
 
     public function test_debug_endpoint_includes_ai_service(): void


### PR DESCRIPTION
## Changes

- Moved debug/info endpoint from root (`/`) to `/debug`
- Added new root endpoint (`/`) that returns welcome JSON message
- Updated tests to reflect the changes

## Endpoints

### GET /
Returns simple welcome JSON:
```json
{
  "message": "Welcome to MovieMind API",
  "status": "ok",
  "version": "1.0.0",
  "api": "/api/v1"
}
```

### GET /debug
Returns detailed API information (moved from root):
- API name, version, status
- Environment info
- AI service configuration
- Active feature flags
- Available endpoints
- Documentation links

## Tests
- ✅ All tests passing (200 tests)
- ✅ Updated `ExampleTest` to test new endpoints
- ✅ Added test for welcome JSON endpoint

## Commits
- `3fbce72` refactor: move root endpoint to /debug and add welcome endpoint
- `762d76b` fix: change root endpoint to return welcome JSON instead of HTML view