### PR TITLE
docs(mcp): tool usage (locale, query, context_tag)

### DIFF
--- a/docs/mcp/MCP_CLIENT_EXAMPLES.md
+++ b/docs/mcp/MCP_CLIENT_EXAMPLES.md
@@ -36,18 +36,29 @@ Add to `~/.cursor/mcp.json` or your project's `.cursor/mcp.json`:
 ```
 
 **Usage:**
+
 - No local setup required
 - Access from anywhere
 - Requires authentication token
 - Uses public MovieMind API
 
 **How to use in Cursor:**
+
+Argument to the search tool is **`query`** (substring of title), not `title_query`.
+
 ```typescript
-// Call via MCP client in Cursor
+// Polish descriptions (default locale)
 await CallMcpTool({
   server: "user-moviemind_remote",
   toolName: "search_database_movies",
-  arguments: { title_query: "Matrix" }
+  arguments: { query: "Matrix" },
+});
+
+// Latest description for another locale (must match API enum)
+await CallMcpTool({
+  server: "user-moviemind_remote",
+  toolName: "search_database_movies",
+  arguments: { query: "Prestige", locale: "en-US" },
 });
 ```
 
@@ -77,6 +88,7 @@ await CallMcpTool({
 ```
 
 **Usage:**
+
 - Direct database access
 - Admin operations (retry failed jobs, clear cache)
 - Requires local Docker environment
@@ -86,7 +98,9 @@ await CallMcpTool({
 
 ## Configuration for Claude Desktop
 
-Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+Add to Claude Desktop config: on macOS
+`~/Library/Application Support/Claude/claude_desktop_config.json`, on Windows
+`%APPDATA%\Claude\claude_desktop_config.json`.
 
 ### Remote MCP via SSE
 
@@ -156,10 +170,10 @@ const client = new Client(
 
 await client.connect(transport);
 
-// Call tools
+// Call tools (see "Tool parameters" below for locale and generation)
 const result = await client.callTool({
   name: "search_database_movies",
-  arguments: { title_query: "Matrix" }
+  arguments: { query: "Matrix", locale: "pl-PL" },
 });
 ```
 
@@ -194,6 +208,34 @@ await client.connect(transport);
 
 ---
 
+## Tool parameters (MovieMind MCP)
+
+### `search_database_movies`
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `query` | yes | Substring matched against movie title (`ILIKE %query%`). |
+| `locale` | no | Language for `current_description`. Default `pl-PL`. Allowed: `en-US`, `pl-PL`, `de-DE`, `fr-FR`, `es-ES`. |
+
+`locale` is sent as a bound SQL parameter (`$2`), not concatenated into the query.
+
+Each row may include `current_description`, `context_tag`, `description_created_at`, and
+`description_locale` (the locale filter that was applied).
+
+### `generate_ai_description`
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `entity_type` | yes | Use lowercase in MCP: `movie`, `person`, `tv_show`, `tv_series` (API gets uppercase). |
+| `slug` or `entity_id` | one of them | Backend slug, e.g. `the-prestige-2006`. |
+| `locale` | no | e.g. `pl-PL`, `en-US` (must match API `Locale`). |
+| `context_tag` | no | `modern`, `critical`, `humorous` (lowercase), or `DEFAULT`. Wrong casing → **422**. |
+
+After `generate_ai_description`, poll **`check_job_status`** until `DONE`, then **`search_database_movies`**
+with the same **`locale`** to read the saved text.
+
+---
+
 ## Environment Variables Reference
 
 ### Required (for both STDIO and SSE)
@@ -221,9 +263,9 @@ await client.connect(transport);
 
 ### End-User Tools (available in both local and remote)
 
-- `search_database_movies` - Search movies by title
-- `generate_ai_description` - Generate AI description for a movie/person
-- `check_job_status` - Check generation job status
+- `search_database_movies` — `query` plus optional `locale` (default `pl-PL`)
+- `generate_ai_description` — queue AI text; set `locale` and lowercase `context_tag`
+- `check_job_status` — poll job by `job_id`
 
 ### DevOps Tools (available only in local STDIO)
 
@@ -265,7 +307,7 @@ async function test() {
   
   const result = await client.callTool({
     name: "search_database_movies",
-    arguments: { title_query: "Matrix" }
+    arguments: { query: "Matrix" },
   });
   
   console.log(JSON.stringify(result, null, 2));
@@ -304,6 +346,7 @@ curl http://localhost:3000/sse
 **Cause:** Environment variables are incorrect or database is not running.
 
 **Fix:**
+
 1. Check Docker: `docker compose ps`
 2. Verify env vars match your `.env` file
 3. For remote: ensure Railway env vars are set correctly
@@ -313,6 +356,16 @@ curl http://localhost:3000/sse
 **Cause:** Remote Railway server is running outdated code.
 
 **Fix:** Redeploy Railway after merging latest PR to `main`.
+
+### "search_database_movies: unsupported locale ..."
+
+**Cause:** `locale` is not one of the allowed API values.
+
+**Fix:** Use exactly `en-US`, `pl-PL`, `de-DE`, `fr-FR`, or `es-ES`, or omit `locale` for default Polish.
+
+### 422 on `context_tag`
+
+**Cause:** Backend expects enum values such as `modern` / `humorous` (lowercase), not `MODERN`.
 
 ### "LARAVEL_ADMIN_TOKEN is required"
 

--- a/docs/mcp/MOVIEMIND_MCP_ANALYSIS.md
+++ b/docs/mcp/MOVIEMIND_MCP_ANALYSIS.md
@@ -123,6 +123,11 @@ Dla `End-User MCP` sens mają:
 - `search_database_movies`,
 - `check_job_status`.
 
+`search_database_movies` przyjmuje **`query`** (fragment tytułu) oraz opcjonalnie **`locale`**
+(`en-US`, `pl-PL`, `de-DE`, `fr-FR`, `es-ES`; domyślnie `pl-PL`), żeby w polu
+`current_description` pokazać **najnowszy** opis w wybranym języku — bez
+sztywnego `pl-PL` w SQL.
+
 Dla `DevOps MCP` sens mają dodatkowo:
 
 - `dispatch_job_retry`,

--- a/docs/mcp/QA_DOCUMENT.md
+++ b/docs/mcp/QA_DOCUMENT.md
@@ -20,7 +20,7 @@ Konstrukcja w klasie transportowej ma nałożony obligatoryjny filtr adresowany 
 |----|---------------------------------|---------------------------------|------------------|---------------------------------------|-----------|
 | **SEC-01** | Weryfikacja odrzucenia bez Bearer | Serwer uruchomiony w trybie wirtualnym `env TRANSPORT_TYPE=sse` | Próba wykonania klienta zapytania WebHook "GET /sse" bez żadnego klucza w nagłówku. | Aplikacja zwraca twardy wyciek `HTTP 401 Unauthorized Access`. Brak zestawienia potoku zdarzeń EventSource. | P1(Krytyczny) |
 | **SEC-02** | Weryfikacja akceptacji przez QueryString (Fallback) | JWT wygasł na kliencie. | Podłączenie adresu sieciowego `GET /sse?token=DEBUG_TOKEN123`. | Utworzony po weryfikacji most SSE 24/7 pomyślnie emituje powitalny paczek od instancji "moviemind-mcp-server". | P2 |
-| **SEC-03** | Injection na `search_database_movies` | Aplikacja odblokowana | Zapytanie przez chat do bota (narzędzia `query` pola) w którym query SQL wynosi np. `' OR 1=1; DROP TABLE movies; --`. | Parametr wpada do paczki PostgreSQL ORM'u przez mechanizm Bindings (`$1`). Znacznik z dropem traktowany jest po prostu jak ciąg do "ILIKE", nie powodując egzekucji polecenia DML ani Exceptionu. | P1(Krytyczny) |
+| **SEC-03** | Injection na `search_database_movies` | Aplikacja odblokowana | Zapytanie przez chat do bota (narzędzia `query` pola) w którym query SQL wynosi np. `' OR 1=1; DROP TABLE movies; --`. | Tytuł trafia do `ILIKE` jako binding (`$1`). Opcjonalny `locale` jest whitelistą API i trafia jako `$2` (nie sklejany w SQL). | P1(Krytyczny) |
 
 ---
 

--- a/mcp-server/build/index.js
+++ b/mcp-server/build/index.js
@@ -60,7 +60,7 @@ const resourceDefinitions = [
 const toolDefinitions = [
     {
         name: "search_database_movies",
-        description: "Queries PostgreSQL for movies by title keyword. Optional locale picks the latest description for that locale (default pl-PL).",
+        description: "Queries PostgreSQL for movies by title substring. Optional locale selects the latest description for that locale (default pl-PL).",
         inputSchema: {
             type: "object",
             properties: {
@@ -84,7 +84,10 @@ const toolDefinitions = [
                 entity_id: { type: "string", description: "Legacy field; if slug is not provided, it will be sent as a slug to the backend" },
                 slug: { type: "string", description: "Entity slug in Laravel backend, e.g. inception-2010" },
                 locale: { type: "string", description: "Target language (e.g. pl-PL)" },
-                context_tag: { type: "string", description: "Optional generation context, e.g. modern or critical" },
+                context_tag: {
+                    type: "string",
+                    description: "Style: modern, critical, humorous (lowercase), or DEFAULT — must match API ContextTag enum",
+                },
             },
             required: ["entity_type"],
         },

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -99,7 +99,7 @@ const toolDefinitions: McpToolDefinition[] = [
   {
     name: "search_database_movies",
     description:
-      "Queries PostgreSQL for movies by title keyword. Optional locale picks the latest description for that locale (default pl-PL).",
+      "Queries PostgreSQL for movies by title substring. Optional locale selects the latest description for that locale (default pl-PL).",
     inputSchema: {
       type: "object",
       properties: {
@@ -124,7 +124,11 @@ const toolDefinitions: McpToolDefinition[] = [
         entity_id: { type: "string", description: "Legacy field; if slug is not provided, it will be sent as a slug to the backend" },
         slug: { type: "string", description: "Entity slug in Laravel backend, e.g. inception-2010" },
         locale: { type: "string", description: "Target language (e.g. pl-PL)" },
-        context_tag: { type: "string", description: "Optional generation context, e.g. modern or critical" },
+        context_tag: {
+          type: "string",
+          description:
+            "Style: modern, critical, humorous (lowercase), or DEFAULT — must match API ContextTag enum",
+        },
       },
       required: ["entity_type"],
     },


### PR DESCRIPTION
## Summary

Documentation and a small MCP tool schema clarification aligned with current server behaviour after #266.

## Changes

- **MCP_CLIENT_EXAMPLES.md** — `search_database_movies` / `generate_ai_description` parameter tables; correct `query` (not `title_query`); examples with `locale`; troubleshooting.
- **MOVIEMIND_MCP_ANALYSIS.md** — short note on optional `locale` for search.
- **QA_DOCUMENT.md** — SEC-03 updated for `$2` locale binding.
- **mcp-server** — clearer `context_tag` description in tool schema; `npm run build`.


Made with [Cursor](https://cursor.com)